### PR TITLE
Try and fix Griddy Gibbs error in spBreg

### DIFF
--- a/R/spBreg.R
+++ b/R/spBreg.R
@@ -326,9 +326,10 @@ spBreg_lag <- function(formula, data = list(), listw, na.action, Durbin, type,
             cond <- den <= rnd
             if (any(cond)) {
 #	ind = which(den <= rnd)
-	        idraw = which.min(cond) - 1 #max(ind)
+		idraw <- max(which(cond))
+		#idraw = which.min(cond) - 1 #max(ind)
 #	    if (idraw > 0 & idraw < nrho) 
-                rho = detval1[idraw]#FIXME: This sometimes fail...
+                rho = detval1[idraw]#FIXME: This sometimes fail... #nk027:Tried
             } else {
                 rho_out = rho_out+1
             }


### PR DESCRIPTION
Apparently the Griddy Gibbs step sometimes fails:

```
if (any(cond)) {
    idraw = which.min(cond) - 1 #max(ind)
    rho = detval1[idraw]#FIXME: This sometimes fail...
}
```

Afaik the idea of this step (as implemented in MATLAB) is to get the position of the last `TRUE` value (`ind = find(den <= rnd); idraw = max(ind);`).

This differs from the logic here - i.e. looking for the first `FALSE` and returning the prior position. I'm unsure whether this actually occurs, but if we have `cond == c(FALSE, TRUE, TRUE, TRUE, FALSE)` this fails. If we want the last `TRUE` value `max(which(cond))` seems more appropriate. The approach here will yield *0* and fail subsequently.